### PR TITLE
Improved the sorting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,12 @@ extensions += [
 if USE_CYTHON:
     from Cython.Build import cythonize
 
-    with_debug = True
+    with_debug = False
     extensions = cythonize(
-        extensions, gdb_debug=with_debug, annotate=False, language_level="3"
+        extensions,
+        gdb_debug=with_debug,
+        annotate=True,
+        language_level="3",
     )
 
 setup(

--- a/src/adaXT/decision_tree/splitter.pxd
+++ b/src/adaXT/decision_tree/splitter.pxd
@@ -6,6 +6,7 @@ cdef class Splitter:
     cdef:
         double[:, ::1] features
         double[::1] response
+        int current_feature
         int n_features
         int[:] indices
         int n_indices
@@ -14,6 +15,7 @@ cdef class Splitter:
         double* class_labels
         int* n_in_class
 
-    cdef cnp.ndarray sort_feature(self, int[::1], double[:])
+
+    cdef int[::1] sort_feature(self, int[::1], int)
 
     cpdef get_split(self, int[::1], int[::1])

--- a/src/adaXT/decision_tree/splitter.pxd
+++ b/src/adaXT/decision_tree/splitter.pxd
@@ -6,7 +6,6 @@ cdef class Splitter:
     cdef:
         double[:, ::1] features
         double[::1] response
-        int current_feature
         int n_features
         int[:] indices
         int n_indices
@@ -15,7 +14,5 @@ cdef class Splitter:
         double* class_labels
         int* n_in_class
 
-
-    cdef int[::1] sort_feature(self, int[::1], int)
 
     cpdef get_split(self, int[::1], int[::1])

--- a/src/adaXT/decision_tree/splitter.pxd
+++ b/src/adaXT/decision_tree/splitter.pxd
@@ -14,5 +14,4 @@ cdef class Splitter:
         double* class_labels
         int* n_in_class
 
-
     cpdef get_split(self, int[::1], int[::1])

--- a/src/adaXT/decision_tree/splitter.pyx
+++ b/src/adaXT/decision_tree/splitter.pyx
@@ -19,11 +19,11 @@ cdef double[:] current_feature_values
 cdef int compare(const void* a, const void* b) noexcept nogil:
     cdef:
         int a1 = (<int *> a)[0]
-        int b1 = ( <int *> b )[0]
+        int b1 = (<int *> b)[0]
 
     if  current_feature_values[a1] >= current_feature_values[b1]:
         return 1
-    if current_feature_values[a1] < current_feature_values[b1]:
+    else:
         return -1
 
 cdef int[::1] sort_feature(int[::1] indices):

--- a/src/adaXT/decision_tree/splitter.pyx
+++ b/src/adaXT/decision_tree/splitter.pyx
@@ -5,7 +5,6 @@ cimport numpy as cnp
 cnp.import_array()
 from ..criteria.criteria cimport Criteria  # Must be complete path for cimport
 from libc.stdlib cimport qsort
-from cython cimport view
 
 cdef double EPSILON = 2*np.finfo('double').eps
 # The rounding error for a criteria function is set twice as large as in DepthTreeBuilder.
@@ -72,7 +71,6 @@ cdef class Splitter:
         self.n_features = X.shape[1]
         self.criteria = criteria
         self.n_class = len(np.unique(Y))
-
 
     cpdef get_split(self, int[::1] indices, int[::1] feature_indices):
         """


### PR DESCRIPTION
The sorting used to use numpys argsort. This is larger for large lists, but as we often call the sorting for smaller lists, the overhead of going to python for the small calls far outweighs the improvements numpy gives. As such this change instead makes use of the quicksort algorithm in the standard c library.