### PR TITLE
Fixed sampling_parameter=None issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import numpy as np
 from setuptools import setup, Extension, find_packages
 
 NAME = "adaXT"
-VERSION = "1.1.0"
+VERSION = "1.2.1"
 DESCRIPTION = "A Python package for tree-based regression and classification"
 PROJECT_URLS = {
     "Documentation": "https://NiklasPfister.github.io/adaXT/",

--- a/src/adaXT/random_forest/random_forest.py
+++ b/src/adaXT/random_forest/random_forest.py
@@ -38,7 +38,12 @@ def get_sample_indices(
     RandomForest.
     """
     if sampling == "bootstrap":
-        return (random_state.randint(low=0, high=n_rows, size=sampling_parameter), None)
+        return (
+            random_state.randint(
+                low=0,
+                high=n_rows,
+                size=sampling_parameter),
+            None)
     elif sampling == "honest_tree":
         indices = np.arange(0, n_rows)
         random_state.shuffle(indices)
@@ -122,8 +127,10 @@ def fill_with_zeros_for_missing_classes_in_tree(
 
 
 def predict_proba_single_tree(
-    tree: DecisionTree, predict_values: np.ndarray, classes: np.ndarray, **kwargs
-):
+        tree: DecisionTree,
+        predict_values: np.ndarray,
+        classes: np.ndarray,
+        **kwargs):
     tree_predict_proba = tree.predict_proba(predict_values)
     ret_val = fill_with_zeros_for_missing_classes_in_tree(
         tree.classes,
@@ -135,7 +142,10 @@ def predict_proba_single_tree(
     return ret_val
 
 
-def predict_single_tree(tree: DecisionTree, predict_values: np.ndarray, **kwargs):
+def predict_single_tree(
+        tree: DecisionTree,
+        predict_values: np.ndarray,
+        **kwargs):
     return tree.predict(predict_values, **kwargs)
 
 
@@ -149,7 +159,8 @@ def shared_numpy_array(array):
     else:
         row = array.shape[0]
         shared_array = RawArray(ctypes.c_double, row)
-        shared_array_np = np.ndarray(shape=row, dtype=np.double, buffer=shared_array)
+        shared_array_np = np.ndarray(
+            shape=row, dtype=np.double, buffer=shared_array)
     np.copyto(shared_array_np, array)
     return shared_array_np
 
@@ -226,7 +237,12 @@ class RandomForest(BaseModel):
         splitter : Splitter | None, optional
             Splitter class if None uses premade Splitter class
         """
-        self.check_tree_type(forest_type, criteria, splitter, leaf_builder, predict)
+        self.check_tree_type(
+            forest_type,
+            criteria,
+            splitter,
+            leaf_builder,
+            predict)
         self.ctx = multiprocessing.get_context("spawn")
         self.X, self.Y = None, None
         self.max_features = max_features
@@ -277,10 +293,14 @@ class RandomForest(BaseModel):
                     "The provided splitting index (given as the first entry in sampling_parameter) is not an integer"
                 )
             if (split_idx > self.n_rows) or (split_idx < 0):
-                raise ValueError("The split index does not fit for the given dataset")
+                raise ValueError(
+                    "The split index does not fit for the given dataset")
 
             if isinstance(number_chosen, float):
-                return (split_idx, max(round(self.n_rows * sampling_parameter), 1))
+                return (
+                    split_idx, max(
+                        round(
+                            self.n_rows * sampling_parameter), 1))
             elif isinstance(number_chosen, int):
                 return (split_idx, number_chosen)
 
@@ -452,9 +472,8 @@ class RandomForest(BaseModel):
 
         return X, Y
 
-    def fit(
-        self, X: np.ndarray, Y: np.ndarray, sample_weight: np.ndarray | None = None
-    ):
+    def fit(self, X: np.ndarray, Y: np.ndarray,
+            sample_weight: np.ndarray | None = None):
         """
         Function used to fit a forest using many DecisionTrees for the given data
 
@@ -476,7 +495,8 @@ class RandomForest(BaseModel):
             self.sample_weight = np.ones(self.X.shape[0])
         else:
             self.sample_weight = sample_weight
-        self.sampling_parameter = self.__get_sampling_parameter(self.sampling_parameter)
+        self.sampling_parameter = self.__get_sampling_parameter(
+            self.sampling_parameter)
         # Fit trees
         self.__build_trees()
 
@@ -542,7 +562,8 @@ class RandomForest(BaseModel):
         # Predict_proba using all the trees, each element of list is the
         # predict_proba from one tree
         tree_predictions = self.__predict_proba_trees(X, **kwargs)
-        return self.predict_class.forest_predict_proba(tree_predictions, **kwargs)
+        return self.predict_class.forest_predict_proba(
+            tree_predictions, **kwargs)
 
     def __get_forest_matrix(self, scale: bool = False):
         partial_func = partial(get_single_leaf, scale=scale)

--- a/src/adaXT/random_forest/random_forest.py
+++ b/src/adaXT/random_forest/random_forest.py
@@ -38,7 +38,12 @@ def get_sample_indices(
     RandomForest.
     """
     if sampling == "bootstrap":
-        return (random_state.randint(low=0, high=n_rows, size=sampling_parameter), None)
+        return (
+            random_state.randint(
+                low=0,
+                high=n_rows,
+                size=sampling_parameter),
+            None)
     elif sampling == "honest_tree":
         indices = np.arange(0, n_rows)
         random_state.shuffle(indices)
@@ -122,8 +127,10 @@ def fill_with_zeros_for_missing_classes_in_tree(
 
 
 def predict_proba_single_tree(
-    tree: DecisionTree, predict_values: np.ndarray, classes: np.ndarray, **kwargs
-):
+        tree: DecisionTree,
+        predict_values: np.ndarray,
+        classes: np.ndarray,
+        **kwargs):
     tree_predict_proba = tree.predict_proba(predict_values)
     ret_val = fill_with_zeros_for_missing_classes_in_tree(
         tree.classes,
@@ -135,7 +142,10 @@ def predict_proba_single_tree(
     return ret_val
 
 
-def predict_single_tree(tree: DecisionTree, predict_values: np.ndarray, **kwargs):
+def predict_single_tree(
+        tree: DecisionTree,
+        predict_values: np.ndarray,
+        **kwargs):
     return tree.predict(predict_values, **kwargs)
 
 
@@ -149,7 +159,8 @@ def shared_numpy_array(array):
     else:
         row = array.shape[0]
         shared_array = RawArray(ctypes.c_double, row)
-        shared_array_np = np.ndarray(shape=row, dtype=np.double, buffer=shared_array)
+        shared_array_np = np.ndarray(
+            shape=row, dtype=np.double, buffer=shared_array)
     np.copyto(shared_array_np, array)
     return shared_array_np
 
@@ -226,7 +237,12 @@ class RandomForest(BaseModel):
         splitter : Splitter | None, optional
             Splitter class if None uses premade Splitter class
         """
-        self.check_tree_type(forest_type, criteria, splitter, leaf_builder, predict)
+        self.check_tree_type(
+            forest_type,
+            criteria,
+            splitter,
+            leaf_builder,
+            predict)
         self.ctx = multiprocessing.get_context("spawn")
         self.X, self.Y = None, None
         self.max_features = max_features
@@ -266,7 +282,8 @@ class RandomForest(BaseModel):
             )
         elif self.sampling == "honest_forest":
             if sampling_parameter is None:
-                sampling_parameter = (int(self.n_rows / 2), int(self.n_rows / 2))
+                sampling_parameter = (
+                    int(self.n_rows / 2), int(self.n_rows / 2))
             elif not isinstance(sampling_parameter, tuple):
                 raise ValueError(
                     "The provided sampling parameter is not a\
@@ -284,7 +301,10 @@ class RandomForest(BaseModel):
                 )
 
             if isinstance(number_chosen, float):
-                return (split_idx, max(round(self.n_rows * sampling_parameter), 1))
+                return (
+                    split_idx, max(
+                        round(
+                            self.n_rows * sampling_parameter), 1))
             elif isinstance(number_chosen, int):
                 return (split_idx, number_chosen)
 
@@ -460,9 +480,8 @@ class RandomForest(BaseModel):
 
         return X, Y
 
-    def fit(
-        self, X: np.ndarray, Y: np.ndarray, sample_weight: np.ndarray | None = None
-    ):
+    def fit(self, X: np.ndarray, Y: np.ndarray,
+            sample_weight: np.ndarray | None = None):
         """
         Function used to fit a forest using many DecisionTrees for the given data
 
@@ -484,7 +503,8 @@ class RandomForest(BaseModel):
             self.sample_weight = np.ones(self.X.shape[0])
         else:
             self.sample_weight = sample_weight
-        self.sampling_parameter = self.__get_sampling_parameter(self.sampling_parameter)
+        self.sampling_parameter = self.__get_sampling_parameter(
+            self.sampling_parameter)
         # Fit trees
         self.__build_trees()
 
@@ -550,7 +570,8 @@ class RandomForest(BaseModel):
         # Predict_proba using all the trees, each element of list is the
         # predict_proba from one tree
         tree_predictions = self.__predict_proba_trees(X, **kwargs)
-        return self.predict_class.forest_predict_proba(tree_predictions, **kwargs)
+        return self.predict_class.forest_predict_proba(
+            tree_predictions, **kwargs)
 
     def __get_forest_matrix(self, scale: bool = False):
         partial_func = partial(get_single_leaf, scale=scale)


### PR DESCRIPTION
In the previous version sampling_parameter=None with sampling='honest_tree' or 'honest_forest' caused an error because the default was not converted to an int.

Also removed two old imports.